### PR TITLE
Query params don't have to declared in route path

### DIFF
--- a/exercises/views/problem.md
+++ b/exercises/views/problem.md
@@ -47,7 +47,7 @@ surrounding the variable with curly braces, e.g. `{{foo}}`.
 
 The template receives some information from the request. For example, the query
 parameters that were passed in via the URL are available in the `query` object.
-These parameters can then be used in the template.
+These parameters can then be used in the template. Query params don't have to be declared in the route `path`.
 
 ```html
 <div>{{query.paramName}}</div>


### PR DESCRIPTION
I definitely got caught up on this going from one exercise to the next, there's probably a better way to explain the distinction between query params and other params.. I'm not even exactly sure of the distinction yet. (But a PR happens to be an easy and great way to communicate my suggestion, and yeah it can be directly and easily merged ;)