### PR TITLE
Optimize workshops installation experience. Closes #108

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,6 @@
   "keywords": [
     "hapijs",
     "hapi"
-  ]
+  ],
+  "preferGlobal": true
 }


### PR DESCRIPTION
This PR is follow-up to discussion and argument raised here:
https://github.com/hapijs/makemehapi/issues/108#issuecomment-69119404

Adding preferGlobal key is supposed to:
- optimize experience for end-users using NPM built-in solution
- improve local workshop development via 'npm link'
- enhance features from services like nodei.co that use
that key to enhance information presented to users

The change is added as last key to prevent problems from stale PR, as this PR can be left open for some time (as per other comments).

Thanks!