### PR TITLE
Fixed solution to cookies problem

### DIFF
--- a/exercises/cookies/solution/solution.js
+++ b/exercises/cookies/solution/solution.js
@@ -9,7 +9,6 @@ server.connection({
 });
 
 server.state('session', {
-  path: '/{path*}',
   encoding: 'base64json',
   ttl: 10,
   domain: 'localhost'
@@ -50,6 +49,12 @@ server.route(
         result = new Hapi.error.unauthorized('Missing authentication');
       }
       reply(result);
+    },
+    config: {
+      state: {
+        parse: true,
+        failAction: 'log'
+      }
     }
   }
 );


### PR DESCRIPTION
Hi there!

The cookies problem says nothing about a path requirement (and the solution's path is a wildcard anyway), but this prevents valid solutions from matching output, so I removed it.

Also, the solution's `/check-cookie` handler forgot its state config, so it systematically failed to see the cookie and always returned an error, when it should have seen the cookie and said OK.

So here goes!