### PR TITLE
Correct validation path, and increase timeout waiting for servers to come online

### DIFF
--- a/exercises/cookies/exercise.js
+++ b/exercises/cookies/exercise.js
@@ -58,7 +58,7 @@ exercise.addProcessor(function (mode, callback) {
 // compare stdout of solution and submissionexercise = comparestdout(exercise)
 exercise = comparestdout(exercise);
 
-// delayed for 500ms to wait for servers to start so we can start
+// delayed for 2000ms to wait for servers to start so we can start
 // playing with them
 function query (mode) {
   var exercise = this

--- a/exercises/directories/exercise.js
+++ b/exercises/directories/exercise.js
@@ -48,7 +48,7 @@ exercise.addProcessor(function (mode, callback) {
         this.solutionStdout = through2();
     }
 
-    setTimeout(query.bind(this, mode), 500);
+    setTimeout(query.bind(this, mode), 2000);
 
     process.nextTick(function () {
         callback(null, true)
@@ -60,7 +60,7 @@ exercise.addProcessor(function (mode, callback) {
 exercise = comparestdout(exercise)
 
 
-// delayed for 500ms to wait for servers to start so we can start
+// delayed for 2000ms to wait for servers to start so we can start
 // playing with them
 function query (mode) {
     var exercise = this

--- a/exercises/handling/exercise.js
+++ b/exercises/handling/exercise.js
@@ -60,7 +60,7 @@ exercise.addProcessor(function (mode, callback) {
 exercise = comparestdout(exercise)
 
 
-// delayed for 500ms to wait for servers to start so we can start
+// delayed for 2000ms to wait for servers to start so we can start
 // playing with them
 function query (mode) {
     var exercise = this

--- a/exercises/hello_hapi/exercise.js
+++ b/exercises/hello_hapi/exercise.js
@@ -59,7 +59,7 @@ exercise.addProcessor(function (mode, callback) {
 exercise = comparestdout(exercise)
 
 
-// delayed for 500ms to wait for servers to start so we can start
+// delayed for 2000ms to wait for servers to start so we can start
 // playing with them
 function query (mode) {
     var exercise = this

--- a/exercises/helping/exercise.js
+++ b/exercises/helping/exercise.js
@@ -48,7 +48,7 @@ exercise.addProcessor(function (mode, callback) {
         this.solutionStdout = through2();
     }
 
-    setTimeout(query.bind(this, mode), 500);
+    setTimeout(query.bind(this, mode), 2000);
 
     process.nextTick(function () {
         callback(null, true);
@@ -60,7 +60,7 @@ exercise.addProcessor(function (mode, callback) {
 exercise = comparestdout(exercise);
 
 
-// delayed for 500ms to wait for servers to start so we can start
+// delayed for 2000ms to wait for servers to start so we can start
 // playing with them
 function query (mode) {
     var exercise = this;

--- a/exercises/proxies/exercise.js
+++ b/exercises/proxies/exercise.js
@@ -64,7 +64,7 @@ exercise.addProcessor(function (mode, callback) {
         this.solutionStdout = through2();
     }
 
-    setTimeout(query.bind(this, mode), 500);
+    setTimeout(query.bind(this, mode), 2000);
 
     process.nextTick(function () {
         callback(null, true)
@@ -76,7 +76,7 @@ exercise.addProcessor(function (mode, callback) {
 exercise = comparestdout(exercise)
 
 
-// delayed for 500ms to wait for servers to start so we can start
+// delayed for 2000ms to wait for servers to start so we can start
 // playing with them
 function query (mode) {
     var exercise = this

--- a/exercises/routes/exercise.js
+++ b/exercises/routes/exercise.js
@@ -59,7 +59,7 @@ exercise.addProcessor(function (mode, callback) {
 exercise = comparestdout(exercise)
 
 
-// delayed for 500ms to wait for servers to start so we can start
+// delayed for 2000ms to wait for servers to start so we can start
 // playing with them
 function query (mode) {
     var exercise = this

--- a/exercises/streams/exercise.js
+++ b/exercises/streams/exercise.js
@@ -54,7 +54,7 @@ exercise.addProcessor(function (mode, callback) {
 });
 
 
-// delayed for 500ms to wait for servers to start so we can start
+// delayed for 2000ms to wait for servers to start so we can start
 // playing with them
 function query (mode) {
 

--- a/exercises/uploads/exercise.js
+++ b/exercises/uploads/exercise.js
@@ -48,7 +48,7 @@ exercise.addProcessor(function (mode, callback) {
     this.solutionStdout = through2();
   }
 
-  setTimeout(query.bind(this, mode), 500);
+  setTimeout(query.bind(this, mode), 2000);
 
   process.nextTick(function () {
     callback(null, true);
@@ -60,7 +60,7 @@ exercise.addProcessor(function (mode, callback) {
 exercise = comparestdout(exercise);
 
 
-// delayed for 500ms to wait for servers to start so we can start
+// delayed for 2000ms to wait for servers to start so we can start
 // playing with them
 function query (mode) {
 

--- a/exercises/validation/exercise.js
+++ b/exercises/validation/exercise.js
@@ -65,13 +65,15 @@ function query (mode) {
     var exercise = this
 
     function verify (port, stream) {
+       
+        var url = 'http://localhost:' + port + '/chickens';
 
         function error (err) {
 
-            exercise.emit('fail', 'Error connecting to http://localhost:' + port + ': ' + err.code)
+            exercise.emit('fail', 'Error connecting to ' + url + ': ' + err.code)
         }
 
-        hyperquest.get('http://localhost:' + port + '/')
+        hyperquest.get(url)
             .on('error', error)
             .pipe(bl(function (err, data) {
 

--- a/exercises/validation/exercise.js
+++ b/exercises/validation/exercise.js
@@ -59,7 +59,7 @@ exercise.addProcessor(function (mode, callback) {
 exercise = comparestdout(exercise)
 
 
-// delayed for 500ms to wait for servers to start so we can start
+// delayed for 2000ms to wait for servers to start so we can start
 // playing with them
 function query (mode) {
     var exercise = this

--- a/exercises/validation_using_joi_object/exercise.js
+++ b/exercises/validation_using_joi_object/exercise.js
@@ -46,7 +46,7 @@ exercise.addProcessor(function (mode, callback) {
         this.solutionStdout = through2();
     }
 
-    setTimeout(query.bind(this, mode), 500);
+    setTimeout(query.bind(this, mode), 2000);
 
     process.nextTick(function () {
         callback(null, true);
@@ -58,7 +58,7 @@ exercise.addProcessor(function (mode, callback) {
 exercise = comparestdout(exercise);
 
 
-// delayed for 500ms to wait for servers to start so we can start
+// delayed for 2000ms to wait for servers to start so we can start
 // playing with them
 function query (mode) {
 

--- a/exercises/views/exercise.js
+++ b/exercises/views/exercise.js
@@ -48,7 +48,7 @@ exercise.addProcessor(function (mode, callback) {
         this.solutionStdout = through2();
     }
 
-    setTimeout(query.bind(this, mode), 500);
+    setTimeout(query.bind(this, mode), 2000);
 
     process.nextTick(function () {
         callback(null, true);
@@ -60,7 +60,7 @@ exercise.addProcessor(function (mode, callback) {
 exercise = comparestdout(exercise);
 
 
-// delayed for 500ms to wait for servers to start so we can start
+// delayed for 2000ms to wait for servers to start so we can start
 // playing with them
 function query (mode) {
     var exercise = this;


### PR DESCRIPTION
# Issues
This PR addresses two existing issues:
### #140 Exercises use inconsistent wait times when waiting for servers to come online
#### Problem
(see issue for more complete context) Sometimes one or both of the servers has not come online when the test attempts to execute. 
#### Solution
Make the timeout for all exercises 2000ms. (commit a6845fa)

### #130 the "validation" exercise tests the wrong path
#### Problem
(see issue for more complete context) The __validation__ exercise asks the user to create and endpoint at `/chickens/{breed}`, but the exercise tests for an endpoint at `/`. 
#### Solution
Change the URL used by the __validation__ exercise.js file to include the `/chickens` path. (commit 11cdb01)

# Testing
### #140
I was unable to reproduce #140 when using a local installation of __makemehapi__ however, I was able to constently reproduce the issue with a global installation using the following steps:
1. `npm install -g makemehapi`
2. run  `makemehapi` and select the directories excercise
3. run 
```makemehapi verify /usr/local/lib/node_modules/makemehapi/exercises/directories/solution/solution.js ```

When using the __makemehapi__ master branch, I consistently get something like the following output:
```
✗ Error connecting to http://localhost:8884: ECONNREFUSED

Error: connect ECONNREFUSED
    at errnoException (net.js:904:11)
    at Object.afterConnect [as oncomplete] (net.js:895:19)
```
When using my fork/branch, the verification runs successfully.


### #130
In order to reproduce this issue, it is necessary to use a hapi server with an endpoint for `/` as well as for `/chickens`. Here's a script to use:
```js
/**
 * makemehapi_validation_solution.js
 */
 var Hapi = require('hapi');
var Joi = require('joi');


var server = new Hapi.Server();

server.connection({
    host: 'localhost',
    port: Number(process.argv[2] || 8080)
});

server.route({
    method: 'GET',
    path: '/',
    config: {
        handler: function(request, reply) {
            reply('you asked for this??');
        }
    }
});

server.route({
    method: 'GET',
    path: '/chickens/{breed}',
    config: {
        handler: function (request, reply) {
            reply('You asked for the chicken ' + request.params.breed);
        },
        validate: {
            params: {
                breed: Joi.string().required()
            }
        }
    }
});

server.start();
```
Inside a local copy of __makemehapi__/master, save this script as `makemehapi_validation_solution.js`, then verify it with:
1. run `node makemehapi`, and select the validation exercise
2. run `node makemehapi.js verify makemehapi_validation_solution.js`

#### Expected output:
```
Your submission results compared to the expected:

────────────────────────────────────────────────────────────────────────────────

1.    ACTUAL:  "you asked for this??"
1.  EXPECTED:  "{\"statusCode\":404,\"error\":\"Not Found\"}"

2.    ACTUAL:  ""
2.  EXPECTED:  ""


────────────────────────────────────────────────────────────────────────────────

✗ Submission results match expected

# FAIL

Your solution to VALIDATION didn't pass. Try again!
```
Next, checkout this fork/branch and rerun the same commands. It should now pass.

