### PR TITLE
reword part about port in proxies exercise

### DIFF
--- a/exercises/proxies/problem.md
+++ b/exercises/proxies/problem.md
@@ -1,7 +1,7 @@
 A proxy lets you relay requests from one server/service to another.
 
-Create a server which listens on the port given by the
-second command-line argument, takes any requests to
+Create a server which listens on a port passed from the
+command line, takes any requests to
 the path `/proxy` and proxies them
 to `http://localhost:65535/proxy`.
 


### PR DESCRIPTION
The wording "second command-line argument" makes me think it wants `process.argv[3]` but port is coming in at `process.argv[2]`.

I made it similar to the other exercises that mention port.