### PR TITLE
trim the newlines off stdout when comparing

### DIFF
--- a/exercises/streams/exercise.js
+++ b/exercises/streams/exercise.js
@@ -83,7 +83,7 @@ function query (mode) {
                 if (err)
                     return stream.emit('error', err);
 
-                stream.write(data.toString() + '\n');
+                stream.write(data.toString().trim());
                 stream.end();
             }));
     }

--- a/exercises/views/exercise.js
+++ b/exercises/views/exercise.js
@@ -89,7 +89,7 @@ function query (mode) {
                     return stream.emit('error', err);
                 }
 
-                stream.write(data.toString() + '\n');
+                stream.write(data.toString().trim());
                 stream.end();
             }));
     }


### PR DESCRIPTION
This solves the issue where solutions that do not include a newline at
the end of the file would incorrectly fail the tests.

Closes #154 and #155