### PR TITLE
Updates all exercises to Hapi 9

### DIFF
--- a/exercises/cookies/solution/solution.js
+++ b/exercises/cookies/solution/solution.js
@@ -1,6 +1,5 @@
 var Hapi = require('hapi');
 
-
 var server = new Hapi.Server();
 
 server.connection({
@@ -9,49 +8,43 @@ server.connection({
 });
 
 server.state('session', {
-  path: '/',
-  encoding: 'base64json',
-  ttl: 10,
-  domain: 'localhost'
+    path: '/',
+    encoding: 'base64json',
+    ttl: 10,
+    domain: 'localhost'
 });
 
-server.route(
-  {
+server.route({
     method: 'GET',
     path: '/set-cookie',
     handler: function (request, reply) {
-      return reply({
-        message : 'success'
-      }).state('session', {
-        key : 'makemehapi'
-      });
+        return reply({
+            message : 'success'
+        }).state('session', { key : 'makemehapi' });
     },
     config: {
-      state: {
-        parse: true,
-        failAction: 'log'
-      }
+        state: {
+            parse: true,
+            failAction: 'log'
+        }
     }
-  }
-);
+});
 
-server.route(
-  {
+server.route({
     method: 'GET',
     path: '/check-cookie',
     handler: function (request, reply) {
-      var session = request.state.session;
-      var result;
-      if (session) {
-        result = {
-          user : 'hapi'
-        };
-      } else {
-        result = new Hapi.error.unauthorized('Missing authentication');
-      }
-      reply(result);
-    }
-  }
-);
+        var session = request.state.session;
+        var result;
 
-server.start();
+        if (session) {
+            result = { user : 'hapi' };
+        } else {
+            result = new Hapi.error.unauthorized('Missing authentication');
+        }
+
+        reply(result);
+    }
+});
+
+server.start(function () {});

--- a/exercises/directories/problem.md
+++ b/exercises/directories/problem.md
@@ -13,6 +13,10 @@ file in a directory, e.g. `public/file.html`, which contains the following:
 -----------------------------------------------------------------
 ##HINTS
 
+You'll need to `require` and `register` the inert plugin in this exercise the
+same as in the previous exercise in order to serve the static directory's
+contents.
+
 Handlers can be declared as an object with a directory path:
 
 ```js
@@ -29,7 +33,7 @@ the file system directory structure, and the parameter name does not matter.
 path: "/path/to/somewhere/{param}"
 ```
 
-Be careful: in practice, you’ll need to provide an absolute path to a
-`public` directory in your program’s directory.  To achieve this, you’ll
+Be careful: in practice, you'll need to provide an absolute path to a
+`public` directory in your program's directory.  To achieve this, you'll
 probably need the `path` core module, its `join()` function, and the
 `__dirname` global variable.

--- a/exercises/directories/solution/solution.js
+++ b/exercises/directories/solution/solution.js
@@ -1,6 +1,6 @@
 var Hapi = require('hapi');
+var Inert = require('inert');
 var Path = require('path');
-
 
 var server = new Hapi.Server();
 
@@ -8,6 +8,8 @@ server.connection({
     host: 'localhost',
     port: Number(process.argv[2] || 8080)
 });
+
+server.register(Inert, function () {});
 
 server.route({
     method: 'GET',
@@ -19,4 +21,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});

--- a/exercises/directories/solution_fr/solution.js
+++ b/exercises/directories/solution_fr/solution.js
@@ -1,4 +1,5 @@
 var Hapi = require('hapi');
+var Inert = require('inert');
 var Path = require('path');
 
 var server = new Hapi.Server();
@@ -7,6 +8,8 @@ server.connection({
     host: 'localhost',
     port: Number(process.argv[2] || 8080)
 });
+
+server.register(Inert, function () {});
 
 server.route({
     method: 'GET',
@@ -18,4 +21,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});

--- a/exercises/handling/problem.md
+++ b/exercises/handling/problem.md
@@ -13,8 +13,21 @@ Create a server which responds to requests to `/` with a static HTML file named
 -----------------------------------------------------------------
 ##HINTS
 
+This exercise requires you to install the inert module, which is a Hapi plugin
+for serving static files and directories. You'll need to register the plugin in
+your code in order to serve static files:
+
+```js
+var Inert = require('inert');
+
+server.register(Inert, function (err) {
+    if (err) throw err;
+});
+```
+
 You can declare handlers as objects instead of functions. The object must
-contain one of the following: `file`, `directory`, `proxy`, or `view`.
+contain one of the following: `file` (requires inert plugin), `directory`
+(requires inert plugin), `proxy` (requires h2o2 plugin), or `view` (requires vision plugin).
 
 For example, `handler` can be assigned an object with the `file` key:
 
@@ -24,7 +37,7 @@ handler: {
 }
 ```
 
-Be careful: in practice, you’ll need to provide an absolute path to an
-`index.html` file in your program’s directory.  To achieve this, you’ll
-probably need the `path` core module, its `join()` function, and the
-`__dirname` global variable.
+Be careful: in practice, you'll need to provide an absolute path to an
+`index.html` file in your program's directory. To achieve this, you'll probably
+need the `path` core module, its `join()` function, and the `__dirname` global
+variable.

--- a/exercises/handling/solution/solution.js
+++ b/exercises/handling/solution/solution.js
@@ -1,6 +1,6 @@
 var Hapi = require('hapi');
+var Inert = require('inert');
 var Path = require('path');
-
 
 var server = new Hapi.Server();
 
@@ -8,6 +8,8 @@ server.connection({
     host: 'localhost',
     port: Number(process.argv[2] || 8080)
 });
+
+server.register(Inert, function () {);
 
 server.route({
     method: 'GET',
@@ -17,4 +19,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});

--- a/exercises/handling/solution_fr/solution.js
+++ b/exercises/handling/solution_fr/solution.js
@@ -1,4 +1,5 @@
 var Hapi = require('hapi');
+var Inert = require('inert');
 var Path = require('path');
 
 var server = new Hapi.Server();
@@ -7,6 +8,8 @@ server.connection({
     host: 'localhost',
     port: Number(process.argv[2] || 8080)
 });
+
+server.register(Inert, function () {});
 
 server.route({
     method: 'GET',

--- a/exercises/hello_hapi/problem.fr.md
+++ b/exercises/hello_hapi/problem.fr.md
@@ -47,8 +47,6 @@ Pour que le serveur commence à écouter sur le port défini au préalable,
 appelez la fonction `start()` :
 
 ```js
-server.start(function () {
-  console.log('Server running at:', server.info.uri);
-});
+server.start(function () {});
 ```
 -----------------------------------------------------------------

--- a/exercises/hello_hapi/problem.fr.md
+++ b/exercises/hello_hapi/problem.fr.md
@@ -36,10 +36,10 @@ doivent avoir la même signature :
 ```js
 function handler(request, reply) {
 
-	// `request` a toutes les informations
-	// `reply` gère la réponse au client
+    // `request` a toutes les informations
+    // `reply` gère la réponse au client
 
-	reply({ mustFlow: true });
+    reply({ mustFlow: true });
 }
 ```
 
@@ -47,6 +47,8 @@ Pour que le serveur commence à écouter sur le port défini au préalable,
 appelez la fonction `start()` :
 
 ```js
-server.start();
+server.start(function () {
+  console.log('Server running at:', server.info.uri);
+});
 ```
 -----------------------------------------------------------------

--- a/exercises/hello_hapi/problem.md
+++ b/exercises/hello_hapi/problem.md
@@ -1,13 +1,13 @@
-Create a hapi server that listens on a port passed from the command line and replies with
-"Hello Hapi" when an HTTP GET request is sent to /.
+Create a hapi server that listens on a port passed from the command line and
+replies with "Hello Hapi" when an HTTP GET request is sent to /.
 
 The workshop will execute requests against the server and verify the output.
 
 -----------------------------------------------------------------
 ##HINTS
 
-Create a server that listens on port 8080, if none is passed from the
-command line,  with the following code:
+Create a server that listens on port 8080, if none is passed from the command
+line,  with the following code:
 
 ```js
 var Hapi = require('hapi');
@@ -30,16 +30,19 @@ Handlers can be anonymous functions or separately declared (just like in javascr
 ```js
 function handler(request, reply) {
 
-	//request has all information
-	//reply handles client response
+    //request has all information
+    //reply handles client response
 
-	reply({mustFlow:true});
+    reply({mustFlow:true});
 }
 ```
 
-Calling the `start` function gets a server listening on the assigned port:
+Calling the `start` function gets a server listening on the assigned port. Note
+that a callback is required when calling `start`:
 
 ```js
-server.start();
+server.start(function () {
+  console.log('Server running at:', server.info.uri);
+});
 ```
 -----------------------------------------------------------------

--- a/exercises/hello_hapi/solution/solution.js
+++ b/exercises/hello_hapi/solution/solution.js
@@ -16,4 +16,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});

--- a/exercises/hello_hapi/solution_fr/solution.js
+++ b/exercises/hello_hapi/solution_fr/solution.js
@@ -15,4 +15,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});

--- a/exercises/helping/problem.md
+++ b/exercises/helping/problem.md
@@ -19,6 +19,8 @@ The helper should concatenate the `name` and `suffix` query parameters.
 -----------------------------------------------------------------
 ##HINTS
 
+Be sure to register the vision plugin when attempting to render the template.
+
 Helpers are functions used within templates to perform transformations and other
 data manipulations using the template context or other inputs.
 

--- a/exercises/helping/solution/solution.js
+++ b/exercises/helping/solution/solution.js
@@ -1,6 +1,6 @@
 var Hapi = require('hapi');
+var Vision = require('vision');
 var Path = require('path');
-
 
 var server = new Hapi.Server();
 
@@ -8,6 +8,8 @@ server.connection({
     host: 'localhost',
     port: Number(process.argv[2] || 8080)
 });
+
+server.register(Vision, function () {});
 
 server.views({
     path: Path.join(__dirname, 'templates'),
@@ -25,4 +27,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});

--- a/exercises/helping/solution_fr/solution.js
+++ b/exercises/helping/solution_fr/solution.js
@@ -1,6 +1,6 @@
 var Hapi = require('hapi');
+var Vision = require('vision');
 var Path = require('path');
-
 
 var server = new Hapi.Server();
 
@@ -8,6 +8,8 @@ server.connection({
     host: 'localhost',
     port: Number(process.argv[2] || 8080)
 });
+
+server.register(Vision, function () {});
 
 server.views({
     path: Path.join(__dirname, 'templates'),
@@ -25,4 +27,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});

--- a/exercises/proxies/exercise.js
+++ b/exercises/proxies/exercise.js
@@ -46,7 +46,7 @@ exercise.addSetup(function (mode, callback) {
             reply(exercise.__('greeting'));
         }
     });
-    server.start();
+    server.start(function () {});
 
     process.nextTick(callback);
 });

--- a/exercises/proxies/problem.md
+++ b/exercises/proxies/problem.md
@@ -1,12 +1,22 @@
 A proxy lets you relay requests from one server/service to another.
 
-Create a server which listens on a port passed from the
-command line, takes any requests to
-the path `/proxy` and proxies them
-to `http://localhost:65535/proxy`.
+Create a server which listens on a port passed from the command line, takes any
+requests to the path `/proxy` and proxies them to `http://localhost:65535/proxy`.
 
 -----------------------------------------------------------------
 ##HINTS
+
+This exercise requires you to install the h2o2 module, which is a Hapi plugin
+for handling proxies. You'll need to register the plugin in your code in
+order to use the `proxy` configuration:
+
+```js
+var H2o2 = require('h2o2');
+
+server.register(H2o2, function (err) {
+    if (err) throw err;
+});
+```
 
 The `proxy` key can be used to generate a reverse proxy handler.
 

--- a/exercises/proxies/solution/solution.js
+++ b/exercises/proxies/solution/solution.js
@@ -1,5 +1,5 @@
 var Hapi = require('hapi');
-
+var H2o2 = require('h2o2');
 
 var server = new Hapi.Server();
 
@@ -7,6 +7,8 @@ server.connection({
     host: 'localhost',
     port: Number(process.argv[2] || 8080)
 });
+
+server.register(H2o2, function () {});
 
 server.route({
     method: 'GET',
@@ -19,4 +21,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});

--- a/exercises/routes/problem.md
+++ b/exercises/routes/problem.md
@@ -1,11 +1,10 @@
-Create a hapi server that listens on a port passed from the
-command line and outputs
-"Hello [name]" where [name] is replaced with the path parameter
-supplied to GET /{name}
+Create a hapi server that listens on a port passed from the command line and
+outputs "Hello [name]" where [name] is replaced with the path parameter supplied
+to GET /{name}
 
 
-When you have completed your server, you can run it in the test
-environment with:
+When you have completed your server, you can run it in the test environment
+with:
 
   {appname} run program.js
 
@@ -16,8 +15,8 @@ And once you are ready to verify it then run:
 -----------------------------------------------------------------
 ##HINTS
 
-Create a server that listens on port 8080, if none is passed from the
-command line,  with the following code:
+Create a server that listens on port 8080, if none is passed from the command
+line, with the following code:
 
 ```js
 var Hapi = require('hapi');

--- a/exercises/routes/solution/solution.js
+++ b/exercises/routes/solution/solution.js
@@ -22,4 +22,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});

--- a/exercises/routes/solution_fr/solution.js
+++ b/exercises/routes/solution_fr/solution.js
@@ -25,4 +25,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});

--- a/exercises/streams/solution/solution.js
+++ b/exercises/streams/solution/solution.js
@@ -3,7 +3,6 @@ var Hapi = require('hapi');
 var Path = require('path');
 var Rot13 = require('rot13-transform');
 
-
 var server = new Hapi.Server();
 
 server.connection({
@@ -22,4 +21,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});

--- a/exercises/uploads/problem.md
+++ b/exercises/uploads/problem.md
@@ -1,10 +1,14 @@
-Create a server with an endpoint that accepts an uploaded file to the following path:
+Create a server with an endpoint that accepts an uploaded file to the following
+path:
 
 ```
 /upload
 ```
 
-The endpoint should accept the following keys: description and file. The ```description``` field should be a string describing whatever you want, and ```file``` should be an uploaded file. The endpoint should return a JSON object that follows the following pattern: 
+The endpoint should accept the following keys: description and file. The
+```description``` field should be a string describing whatever you want, and
+```file``` should be an uploaded file. The endpoint should return a JSON object
+that follows the following pattern:
 
 ```json
 {
@@ -20,9 +24,11 @@ The endpoint should accept the following keys: description and file. The ```desc
 -----------------------------------------------------------------
 ##HINTS
 
-To accept a file as input, your request should use the ```multipart/form-data``` header. 
+To accept a file as input, your request should use the ```multipart/form-data```
+header.
 
-We can get a file as readable stream by adding the following in the route configuration:
+We can get a file as readable stream by adding the following in the route
+configuration:
 
 ```js
 
@@ -32,13 +38,14 @@ payload: {
 }
 ```
 
-If we've uploaded the file with the parameter ```file```, then we can access it in the handler function using following code:
+If we've uploaded the file with the parameter ```file```, then we can access it
+in the handler function using following code:
 
 ```js
 handler: function (request, reply) {
     var body = '';
     request.payload.file.on('data', function (data){
-      
+
       body += data
     });
 
@@ -49,5 +56,6 @@ handler: function (request, reply) {
 }
 ```
 
-More information about file uploading can be found in the reply interface of the hapi [API docs](http://hapijs.com/api#reply-interface).
+More information about file uploading can be found in the reply interface of the
+hapi [API docs](http://hapijs.com/api#reply-interface).
 

--- a/exercises/uploads/solution/solution.js
+++ b/exercises/uploads/solution/solution.js
@@ -36,4 +36,4 @@ server.route({
   }
 });
 
-server.start();
+server.start(function () {});

--- a/exercises/uploads/solution_fr/solution.js
+++ b/exercises/uploads/solution_fr/solution.js
@@ -40,4 +40,4 @@ function concatStream(src, cb) {
   src.on('error', function(err)  { cb(err); })
 }
 
-server.start();
+server.start(function () {});

--- a/exercises/validation/solution/solution.js
+++ b/exercises/validation/solution/solution.js
@@ -24,4 +24,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});

--- a/exercises/validation/solution_fr/solution.js
+++ b/exercises/validation/solution_fr/solution.js
@@ -24,4 +24,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});

--- a/exercises/validation_using_joi_object/solution/solution.js
+++ b/exercises/validation_using_joi_object/solution/solution.js
@@ -1,7 +1,6 @@
 var Hapi = require('hapi');
 var Joi = require('joi');
 
-
 var server = new Hapi.Server();
 
 server.connection({
@@ -27,4 +26,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});

--- a/exercises/validation_using_joi_object/solution_fr/solution.js
+++ b/exercises/validation_using_joi_object/solution_fr/solution.js
@@ -1,7 +1,6 @@
 var Hapi = require('hapi');
 var Joi = require('joi');
 
-
 var server = new Hapi.Server();
 
 server.connection({
@@ -27,4 +26,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});

--- a/exercises/views/problem.md
+++ b/exercises/views/problem.md
@@ -13,6 +13,18 @@ located at `templates/index.html` which outputs the following HTML:
 -----------------------------------------------------------------
 ##HINTS
 
+This exercise requires you to install the vision module, which is a Hapi plugin
+for rendering templates. You'll need to register the plugin in your code in
+order to render your templates:
+
+```js
+var Vision = require('vision');
+
+server.register(Vision, function (err) {
+    if (err) throw err;
+});
+```
+
 The `view` key can be used to define the template to be used to generate the
 response.
 

--- a/exercises/views/solution/solution.js
+++ b/exercises/views/solution/solution.js
@@ -1,6 +1,6 @@
 var Hapi = require('hapi');
+var Vision = require('vision');
 var Path = require('path');
-
 
 var server = new Hapi.Server();
 
@@ -8,6 +8,8 @@ server.connection({
     host: 'localhost',
     port: Number(process.argv[2] || 8080)
 });
+
+server.register(Vision, function () {});
 
 server.views({
     engines: {
@@ -24,4 +26,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});

--- a/exercises/views/solution_fr/solution.js
+++ b/exercises/views/solution_fr/solution.js
@@ -1,4 +1,5 @@
 var Hapi = require('hapi');
+var Vision = require('vision');
 var Path = require('path');
 
 var server = new Hapi.Server();
@@ -7,6 +8,8 @@ server.connection({
     host: 'localhost',
     port: Number(process.argv[2] || 8080)
 });
+
+server.register(Vision, function () {});
 
 server.views({
     engines: {
@@ -23,4 +26,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "combined-stream": "^1.0.5",
     "form-data": "^0.2.0",
     "handlebars": "^3.0.0",
-    "hapi": "8.x.x",
+    "hapi": "9.x.x",
     "hyperquest": "^1.0.1",
     "joi": "6.x.x",
     "rot13-transform": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "handlebars": "^3.0.0",
     "hapi": "9.x.x",
     "hyperquest": "^1.0.1",
+    "inert": "3.x.x",
     "joi": "6.x.x",
     "rot13-transform": "^0.0.1",
     "through2": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "joi": "6.x.x",
     "rot13-transform": "^0.0.1",
     "through2": "^2.0.0",
+    "vision": "2.x.x",
     "workshopper": "^2.3.1",
     "workshopper-boilerplate": "^1.1.0",
     "workshopper-exercise": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "colors-tmpl": "^1.0.0",
     "combined-stream": "^1.0.5",
     "form-data": "^0.2.0",
+    "h2o2": "4.x.x",
     "handlebars": "^3.0.0",
     "hapi": "9.x.x",
     "hyperquest": "^1.0.1",


### PR DESCRIPTION
This updates each of the exercises to use Hapi 9. In most cases it's the
addition of a callback in the #start method, but in others it's the inclusion of
a plugin.

This includes solutions for all French translations as well; however, the French
copy will need some updates/additions.

Adds the following dependencies:

* h2o2: 4.x.x
* inert: 3.x.x
* vision: 2.x.x

Updates the following dependencies:

* hapi: 9.x.x

Closes #158.