### PR TITLE
Fixing typo in handling exercise solution

### DIFF
--- a/exercises/handling/solution/solution.js
+++ b/exercises/handling/solution/solution.js
@@ -9,7 +9,7 @@ server.connection({
     port: Number(process.argv[2] || 8080)
 });
 
-server.register(Inert, function () {);
+server.register(Inert, function () {});
 
 server.route({
     method: 'GET',

--- a/exercises/handling/solution_fr/solution.js
+++ b/exercises/handling/solution_fr/solution.js
@@ -19,4 +19,4 @@ server.route({
     }
 });
 
-server.start();
+server.start(function () {});


### PR DESCRIPTION
A closing bracket was forgotten as well as an empty function for the `start` function, which is needed.