### PR TITLE
Correct an issue with comparing HTML in handling.

### DIFF
--- a/exercises/handling/exercise.js
+++ b/exercises/handling/exercise.js
@@ -88,7 +88,7 @@ function query (mode) {
                 if (err)
                     return stream.emit('error', err)
 
-                stream.write(data.toString() + '\n');
+                stream.write(data.toString().trim());
                 stream.end();
             }));
     }


### PR DESCRIPTION
Ignore trailing whitespace when verifying the handling exercise.

Closes #175