### PR TITLE
Update solutions for cookie exercise so that tests pass

### DIFF
--- a/exercises/cookies/solution/solution.js
+++ b/exercises/cookies/solution/solution.js
@@ -12,7 +12,10 @@ server.state('session', {
     path: '/',
     encoding: 'base64json',
     ttl: 10,
-    domain: 'localhost'
+    domain: 'localhost',
+    isSameSite: false,
+    isSecure: false,
+    isHttpOnly: false
 });
 
 server.route({


### PR DESCRIPTION
The current solutions do not actually pass the expected tests:

![screen shot 2016-09-01 at 10 39 22 am](https://cloud.githubusercontent.com/assets/2865947/18177751/6df45f10-7030-11e6-9df4-53fe4dc21396.png)

Adding the other options allows for the tests to pass.