### PR TITLE
Disable `confine` option in handling exercise

### DIFF
--- a/exercises/handling/solution/solution.js
+++ b/exercises/handling/solution/solution.js
@@ -2,7 +2,16 @@ var Hapi = require('hapi');
 var Inert = require('inert');
 var Path = require('path');
 
-var server = new Hapi.Server();
+var server = new Hapi.Server({
+    connections: {
+        routes: {
+            files: {
+                relativeTo: __dirname
+            }
+        }
+    }
+});
+
 
 server.connection({
     host: 'localhost',


### PR DESCRIPTION
The `confine` option defaults to `true`, which causes inert to return an
HTTP 403 in some cases. This change explicitly sets the `confine` option
to `false` when responding with a file.

Closes #185 