### PR TITLE
Changed to explicitly set the text line ending to ‘lf’

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@
 
 # Explicitly declare text files we want to always be normalized and converted
 # to native line endings on checkout.
-*.js text
+*.js text eol=lf
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary


### PR DESCRIPTION
I updated the .gitattributes file to modify the line ending of .js files to 'LF'. Current release '5.2.1' has line ending problem in MacOS X. To fix this problem, I believe following steps are needed.

* Update the .gitattributes file in the local repository with the one in this pull request
* Remove the .js files in the local and restore them using 'git reset --hard'
  - The line endings should be fixed at this step
* Release the package via npm
